### PR TITLE
More explicit USAGE string

### DIFF
--- a/rc-gen/src/index.js
+++ b/rc-gen/src/index.js
@@ -14,7 +14,7 @@ const checkArgs = () => {
 
 const main = () => {
   if (!checkArgs()) {
-    console.error('USAGE: Component [OPTIONS: --class, --func]');
+    console.error('USAGE: rc-gen ComponentName [OPTIONS: --class, --func]');
   } else {
     const componentName = args._.join('');
     const componentType = args.class ? 'class' : 'func';


### PR DESCRIPTION
Self-explanatory I guess :) Abides by man pages' standards, where the USAGE mentions the command name explicitly.